### PR TITLE
Fix Humanitix Event URL is incorrectly duplicating the url #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,18 @@ Here's an example of how humanitix is processed. Note: We also process the date 
 
 ## Development on the extension
 
-We recommend you install [web-ext](https://github.com/mozilla/web-ext) locally.
+We recommend you use [web-ext](https://github.com/mozilla/web-ext) to test / develop locally.
 It supports live reloading of your plugin as you change the code.
 
 ```
-brew install web-ext
+# Install dependencies:
+npm install
+```
 
-web-ext run # spins up a firefox instance with your extension live loaded
+Then start web-ext using:
+
+```
+npm run dev
 ```
 
 ## Deploying a build

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### 0.1.3
+
+- Fix Humanitix Event URL is incorrectly duplicating the url
+
 ### 0.1.2
 
 - Add support for Facebook events

--- a/content-script.js
+++ b/content-script.js
@@ -83,7 +83,11 @@ const check = () => {
     }
 
     if (site.domain_name === facebook.domain_name) return handleFacebookIcal()
-    chrome.runtime.sendMessage(extractKoalagatorEventInfoFrom(site))
+    const result = extractKoalagatorEventInfoFrom(site)
+    const website = result.website
+    // __AUTO_GENERATED_PRINT_VAR_START__
+    console.log("check website: %s", website) // __AUTO_GENERATED_PRINT_VAR_END__
+    chrome.runtime.sendMessage(result)
 }
 
 check()
@@ -98,7 +102,7 @@ function extractKoalagatorEventInfoFrom(site) {
     const eventTitle = document.querySelector(site.event_title)?.innerText
     const venueName = document.querySelector(site.venue_name)?.innerText
     const description = document.querySelector(site.description)?.innerText
-    const website = `${location.origin}${location.href}`
+    const website = `${location.href}`
     let dateStart = document.querySelector(site.date_start)
     if (site.date_start_attr) {
         dateStart = dateStart?.getAttribute(site.date_start_attr)

--- a/content-script.js
+++ b/content-script.js
@@ -99,10 +99,6 @@ chrome.runtime.onMessage.addListener((request) => {
 })
 
 function extractKoalagatorEventInfoFrom(site) {
-    const eventTitle = document.querySelector(site.event_title)?.innerText
-    const venueName = document.querySelector(site.venue_name)?.innerText
-    const description = document.querySelector(site.description)?.innerText
-    const website = `${location.href}`
     let dateStart = document.querySelector(site.date_start)
     if (site.date_start_attr) {
         dateStart = dateStart?.getAttribute(site.date_start_attr)
@@ -123,14 +119,18 @@ function extractKoalagatorEventInfoFrom(site) {
         if (data.endDate) dateEnd = data.endDate
     }
 
+    const eventTitle = document.querySelector(site.event_title)?.innerText
+    const venueName = document.querySelector(site.venue_name)?.innerText
+    const description = document.querySelector(site.description)?.innerText
+
     return {
         eventTitle,
         venueName,
+        description,
         dateStart,
         dateEnd,
-        website,
-        description,
         supported: true,
+        website: location.href,
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     },
     "scripts": {
         "format": "prettier --write .",
-        "dev": "web-ext run"
+        "dev": "web-ext run # spins up a firefox instance with your extension live loaded"
     },
     "devDependencies": {
         "prettier": "^3.5.3",


### PR DESCRIPTION
Fixes #2 

## Manual test evidence:

| BEFORE                                                                                                                                                    | AFTER                                                                                                                         |
|-----------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
| https://events.humanitix.comhttps://events.humanitix.com/adelaide-roller-derby-2025-mile-die-club-v-road-train-rollers-and-good-ship-salty-v-wild-hearses | https://events.humanitix.com/adelaide-roller-derby-2025-mile-die-club-v-road-train-rollers-and-good-ship-salty-v-wild-hearses |
| https://www.eventbrite.comhttps://www.eventbrite.com/e/emotional-abuse-support-group-tickets-1356987729829?aff=ehometext                                  | https://www.eventbrite.com/e/emotional-abuse-support-group-tickets-1356987729829?aff=ehometext                                |
| https://www.meetup.comhttps://www.meetup.com/toastmasters-south-australia/events/307665754/?eventOrigin=home_logged_out_near_location                     | https://www.meetup.com/toastmasters-south-australia/events/307665754/?eventOrigin=home_logged_out_near_location               |
| https://www.trybooking.comhttps://www.trybooking.com/events/landing/1394361                                                                               | https://www.trybooking.com/events/landing/1394361                                                                             |
| https://lu.mahttps://lu.ma/0d92umys                                                                                                                       | https://lu.ma/0d92umys                                                                                                        |
| https://ti.tohttps://ti.to/use/this-is-a-tito-event-homepage                                                                                              | https://ti.to/use/this-is-a-tito-event-homepage                                                                               |

## Regression testing:

### FB events were not touched:

https://www.facebook.com/events/666669942919952

Creates [seedbomb event](https://seedbomb.au/events/new?event%5Btitle%5D=effie+isobel+%27Moon+Made%27+Single+Launch&event%5Bstart_time%5D=Fri+Jun+06+2025+19%3A00%3A00+GMT%2B0930+%28Australian+Central+Standard+Time%29&event%5Bend_time%5D=Fri+Jun+06+2025+22%3A00%3A00+GMT%2B0930+%28Australian+Central+Standard+Time%29&event%5Burl%5D=https%3A%2F%2Fwww.facebook.com%2Fevents%2F666669942919952&event%5Bdescription%5D=EEEEEEE%21%21%21+so+excited+to+be+launching+my+newest+single+%27Moon+Made%27+%0A%0AJive+%7E+June+6+%7E+%2410+%28%2BBF%29+presale+%2F%2415+door%0A%0AWith+supports+Perfect+50+%26+TUSHAR%0A%0ATICKETS%3A+%0Ahttps%3A%2F%2Fm.moshtix.com.au%2Fv2%2Fevent%2Feffie-isobel-moon-made-single-launch%2F180849%0A%0AThis+event+is+held+on+the+lands+of+the+Kaurna+People.+We+pay+our+respects+to+Elders+past+and+present+and+acknowledge+that+sovereignty+was+never+ceded%0A%0AAlways+was%2C+always+will+be%0A%0Ahttps%3A%2F%2Fwww.facebook.com%2Fevents%2F666669942919952%2F&venue_name=Jive%2C+181+Hindley+St%2C+Adelaide+SA+5000):

![image](https://github.com/user-attachments/assets/121efa02-b220-475e-b387-bcdc32692c26)

### Other fields are extracted as usual:

https://www.meetup.com/toastmasters-south-australia/events/307665754/?eventOrigin=home_logged_out_near_location

Creates [seedbomb event](https://seedbomb.au/events/new?event%5Btitle%5D=Public+Speaking+Meeting+-+North+Adelaide+Toastmasters&event%5Bstart_time%5D=2025-06-03T18%3A15%3A00%2B09%3A30&event%5Bend_time%5D=2025-06-03T20%3A30%3A00%2B09%3A30&event%5Burl%5D=https%3A%2F%2Fwww.meetup.comhttps%3A%2F%2Fwww.meetup.com%2Ftoastmasters-south-australia%2Fevents%2F307665754%2F%3FeventOrigin%3Dhome_logged_out_near_location&event%5Bdescription%5D=Details%0A%0AAt+North+Adelaide+Toastmasters+you+will+improve+your+speaking+skills+by+speaking+to+groups%2C+and+being+evaluated+and+mentored+in+a+supportive+environment.%0A%0AAt+each+meeting+you+will+have+the+opportunity+to+either+practice+giving+impromptu+speeches%2C+presenting+prepared+speeches%2C+offering+constructive+evaluation%2C+conducting+meetings%2C+and+taking+on+another+speaking+or+leadership+role.%0A%0A%C2%B7+Think+on+your+feet+and+speak+at+short+notice+on+a+wide+variety+of+topics%3B%0A%0A%C2%B7+Communicate+effectively+using+eye+contact%2C+hand+gestures+and+body+language%3B%0A%0A%C2%B7+Prepare+and+deliver+speeches+using+manuals+with+specific+objectives%3B%0A%0A%C2%B7+Enjoy+fellowship+and+support+from+fellow+members%3B%0A%0A%C2%B7+Participate+in+and+run+meetings+efficiently%3B%0A%0A%C2%B7+Become+the+BEST+COMMUNICATOR+you+can%3B+and%0A%0A%C2%B7+Embrace+your+potential+as+a+leader%0A%0AJoin+us+at+North+Adelaide+Toastmasters+%28http%3A%2F%2Fnorthadelaide.toastmastersclubs.org%2F%29+for+this+Toastmasters+meeting.+This+is+the+perfect+place+to+overcome+your+public+speaking+nerves+and+improve+your+public+speaking+abilities.%0A%0ABook+in+now.+Free+for+guests%2C+members+of+our+Meetup+Group%2C+and+visiting+Toastmasters.%0A%0AFind+Directions+Here.+%28http%3A%2F%2Fnorthadelaide.toastmastersclubs.org%2Fdirections.html%29%0A%0ANorth+Adelaide+Toastmasters+meets+on+the+1st+and+3rd+Tuesdays+-+6%3A15pm-8%3A30pm.+Come+as+a+guest+and+get+a+feel+of+Toastmasters+and+our+wonderful+club%21&venue_name=Nailsworth+Community+Hall
):

![image](https://github.com/user-attachments/assets/9307d0e2-761a-4371-b4ed-a6b4b981d25b)



